### PR TITLE
JCR-2422: Failed to save file to a workspace not defined in "allow au…

### DIFF
--- a/exo.jcr.component.webdav/src/main/java/org/exoplatform/services/jcr/webdav/command/PutCommand.java
+++ b/exo.jcr.component.webdav/src/main/java/org/exoplatform/services/jcr/webdav/command/PutCommand.java
@@ -411,6 +411,12 @@ public class PutCommand
       }
 
       List<String> paths = allowedAutoVersionPath.get(workspaceName);
+
+      if (paths == null)
+      {
+         return false;
+      }
+
       for (String p : paths)
       {
          if (!StringUtils.isEmpty(p) && nodePath.startsWith(p))


### PR DESCRIPTION
…to versioning"

Fix description:
* When a workspace doesn't belong to the list of auto-version, the workspace doesn't support this feature.