### PR TITLE
PLF-7397 : do not use URL to work with files in tests, use inputstreams instead

### DIFF
--- a/exo.jcr.component.core/src/test/java/org/exoplatform/services/jcr/impl/core/query/TestArabicSearch.java
+++ b/exo.jcr.component.core/src/test/java/org/exoplatform/services/jcr/impl/core/query/TestArabicSearch.java
@@ -27,8 +27,7 @@ import org.exoplatform.services.jcr.impl.core.NodeImpl;
 import org.exoplatform.services.jcr.impl.core.query.lucene.FieldNames;
 import org.exoplatform.services.jcr.impl.core.query.lucene.Util;
 
-import java.io.FileInputStream;
-import java.net.URL;
+import java.io.InputStream;
 import java.util.Calendar;
 
 import javax.jcr.query.Query;
@@ -49,10 +48,8 @@ public class TestArabicSearch extends BaseQueryTest
    public void testSearchWithEncodingParameter() throws Exception
    {
 
-      URL url = TestArabicSearch.class.getResource("/ArabicUTF8.txt");
-      assertNotNull("ArabicUTF8.txt not found", url);
-
-      FileInputStream fis = new FileInputStream(url.getFile());
+      InputStream inputStream = TestArabicSearch.class.getResourceAsStream("/ArabicUTF8.txt");
+      assertNotNull("ArabicUTF8.txt not found", inputStream);
 
       NodeImpl node = (NodeImpl)root.addNode(fileName, "nt:file");
       NodeImpl cont = (NodeImpl)node.addNode("jcr:content", "nt:resource");
@@ -60,7 +57,7 @@ public class TestArabicSearch extends BaseQueryTest
       cont.setProperty("jcr:lastModified", Calendar.getInstance());
       cont.setProperty("jcr:encoding", "UTF-8");
 
-      cont.setProperty("jcr:data", fis);
+      cont.setProperty("jcr:data", inputStream);
       root.save();
 
       // Arabic word

--- a/exo.jcr.component.core/src/test/java/org/exoplatform/services/jcr/impl/core/query/TestExcelFileSearch.java
+++ b/exo.jcr.component.core/src/test/java/org/exoplatform/services/jcr/impl/core/query/TestExcelFileSearch.java
@@ -31,8 +31,7 @@ import org.exoplatform.services.jcr.impl.core.NodeImpl;
 import org.exoplatform.services.jcr.impl.core.query.lucene.FieldNames;
 import org.exoplatform.services.jcr.impl.core.query.lucene.Util;
 
-import java.io.FileInputStream;
-import java.net.URL;
+import java.io.InputStream;
 import java.util.Calendar;
 
 /**
@@ -46,10 +45,8 @@ public class TestExcelFileSearch extends BaseQueryTest
 
    public void testFindFileContent() throws Exception
    {
-      URL url = TestExcelFileSearch.class.getResource("/test.xls");
-      assertNotNull("test.xls not found", url);
-
-      FileInputStream fis = new FileInputStream(url.getFile());
+      InputStream inputStream = TestExcelFileSearch.class.getResourceAsStream("/test.xls");
+      assertNotNull("test.xls not found", inputStream);
 
       NodeImpl node = (NodeImpl)root.addNode("excelFile", "nt:file");
       NodeImpl cont = (NodeImpl)node.addNode("jcr:content", "nt:resource");
@@ -57,11 +54,11 @@ public class TestExcelFileSearch extends BaseQueryTest
       cont.setProperty("jcr:lastModified", Calendar.getInstance());
       // cont.setProperty("jcr:encoding","UTF-8");
 
-      cont.setProperty("jcr:data", fis);
+      cont.setProperty("jcr:data", inputStream);
       root.save();
 
-      fis.close();
-      fis = new FileInputStream(url.getFile());
+      inputStream.close();
+
       DocumentReaderService extr =
          (DocumentReaderService)session.getContainer().getComponentInstanceOfType(DocumentReaderService.class);
 
@@ -81,11 +78,6 @@ public class TestExcelFileSearch extends BaseQueryTest
       {
          fail("Wrong document reader");
       }
-
-      // String text = dreader.getContentAsText(fis);
-
-      // System.out.println(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> \n"+text +
-      // "\n>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
 
       // Arabic word
       String word = "eric";


### PR DESCRIPTION
Jenkins sometimes uses '@' in its folder names, especially in the folder used to checkout the sources. Some tests use Class.getResource(string) to get their test files, which returns an URL and encodes characters (so it encodes '@'). After this encoding, the file path is not good anymore (for example 'sources@2' becomes 'sources%2') and make the test fails.
The fix uses Class.getResourceAsStream(string) and deals with InputStream instead.