### PR TITLE
JCR-2470: hidden ArrayIndexOutOfBoundsException when reindexing data

### DIFF
--- a/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/core/query/lucene/MultiIndex.java
+++ b/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/core/query/lucene/MultiIndex.java
@@ -3720,6 +3720,7 @@ public class MultiIndex implements IndexerIoModeListener, IndexUpdateMonitorList
                      ex.initCause(e);
                      exception.set(ex);
                      // Interrupts all the indexing threads
+                     LOG.error("Issue with indexation",ex);
                      interruptAll();
                   }
                   finally

--- a/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/dataflow/ValueDataUtil.java
+++ b/exo.jcr.component.core/src/main/java/org/exoplatform/services/jcr/impl/dataflow/ValueDataUtil.java
@@ -40,6 +40,8 @@ import org.exoplatform.services.jcr.impl.dataflow.persistent.StringPersistedValu
 import org.exoplatform.services.jcr.impl.storage.value.fs.operations.ValueFileIOHelper;
 import org.exoplatform.services.jcr.impl.util.JCRDateFormat;
 import org.exoplatform.services.jcr.impl.util.io.SwapFile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -61,7 +63,12 @@ import javax.jcr.ValueFormatException;
  */
 public class ValueDataUtil
 {
-   /**
+    /**
+     * The logger instance for this class
+     */
+    private static final Logger LOG = LoggerFactory.getLogger("org.exoplatform.services.jcr.impl.dataflow.ValueDataUtil");
+
+    /**
     * Read value data from stream.
     * 
     * @param cid
@@ -188,6 +195,7 @@ public class ValueDataUtil
          // JCR-2463 In case the file was renamed to be removed/changed,
          // but the transaction wasn't rollbacked cleanly
          file = fixFileName(file);
+         fileSize = file.length();
          FileInputStream is = new FileInputStream(file);
          try
          {
@@ -205,6 +213,9 @@ public class ValueDataUtil
             }
 
             vdDataWrapper.value = createValueData(type, orderNumber, data);
+         }
+         catch (ArrayIndexOutOfBoundsException e) {
+             LOG.error("issue with file read: {} ",file.getAbsolutePath(), e);
          }
          finally
          {

--- a/exo.jcr.component.core/src/test/java/org/exoplatform/services/jcr/impl/storage/value/fs/TestFileValueIO.java
+++ b/exo.jcr.component.core/src/test/java/org/exoplatform/services/jcr/impl/storage/value/fs/TestFileValueIO.java
@@ -90,7 +90,12 @@ public class TestFileValueIO extends TestCase
    {
 
       byte[] buf = "0123456789".getBytes();
-      File file = new File("target/testReadByteArrayValueData");
+      File parentDir= new File("target/parentTestReadByteArrayValueData");
+      if (parentDir.exists()){
+         parentDir.delete();
+      }
+      parentDir.mkdir();
+      File file = new File("target/parentTestReadByteArrayValueData/testReadByteArrayValueData");
       if (file.exists())
          file.delete();
       FileOutputStream out = new FileOutputStream(file);
@@ -100,6 +105,21 @@ public class TestFileValueIO extends TestCase
       // max buffer size = 50 - so ByteArray will be created
       ValueData vd = FileValueIOUtil.testReadValue(file, 0, 50);
 
+      assertTrue(vd instanceof ByteArrayPersistedValueData);
+      assertTrue(vd.isByteArray());
+      assertEquals(10, vd.getLength());
+      assertEquals(0, vd.getOrderNumber());
+      assertEquals(10, vd.getAsByteArray().length);
+      assertTrue(vd.getAsStream() instanceof ByteArrayInputStream);
+      //added test after JCR-2463
+      file = new File("target/parentTestReadByteArrayValueData/testReadByteArrayValueDataTrunc");
+      File truncatedFile = new File("target/parentTestReadByteArrayValueData/testReadByteArrayValueDataTrunc.ori");
+      if (truncatedFile.exists())
+         truncatedFile.delete();
+      out = new FileOutputStream(truncatedFile);
+      out.write(buf);
+      out.close();
+      vd = FileValueIOUtil.testReadValue(file, 0, 50);
       assertTrue(vd instanceof ByteArrayPersistedValueData);
       assertTrue(vd.isByteArray());
       assertEquals(10, vd.getLength());


### PR DESCRIPTION
The issue was observed during Tribe reindexing. The operation were interrupted without error message.
As first approach, I added some logs in order to identify the causing issue. This logs allowed to identify the exception at the origin of the reindexing problem: java.lang.ArrayIndexOutOfBoundsException
When foccusing on the sources, I found that in https://jira.exoplatform.org/browse/JCR-2463 a new method has been added to fetch a new value file. But, after finding it, the size wasn't updated. So, I added this missing part and applied more logs to have alerts when something similar happen in the future
 